### PR TITLE
Add support for custom rubygems_url

### DIFF
--- a/docs/provisioners/chef-client.mdx
+++ b/docs/provisioners/chef-client.mdx
@@ -121,6 +121,10 @@ configuration is actually required.
   then the sudo will be omitted. This has no effect when guest_os_type is
   windows.
 
+- `rubygems_url` (string) - The url of a rubygems source used by the Chef Infra
+  Client when installing gems that cookbooks depend on. This should only be set
+  if you want to override the Chef Infra Client default value.
+
 - `run_list` (array of strings) - The [run
   list](https://docs.chef.io/run_lists) for Chef.
   By default this is empty, and will use the run list sent down by the Chef

--- a/provisioner/chef-client/provisioner.go
+++ b/provisioner/chef-client/provisioner.go
@@ -72,6 +72,7 @@ type Config struct {
 	PolicyGroup                string   `mapstructure:"policy_group"`
 	PolicyName                 string   `mapstructure:"policy_name"`
 	PreventSudo                bool     `mapstructure:"prevent_sudo"`
+	RubygemsURL                string   `mapstructure:"rubygems_url"`
 	RunList                    []string `mapstructure:"run_list"`
 	ServerUrl                  string   `mapstructure:"server_url"`
 	SkipCleanClient            bool     `mapstructure:"skip_clean_client"`
@@ -104,6 +105,7 @@ type ConfigTemplate struct {
 	NodeName                   string
 	PolicyGroup                string
 	PolicyName                 string
+	RubygemsURL                string
 	ServerUrl                  string
 	SslVerifyMode              string
 	TrustedCertsDir            string
@@ -313,7 +315,8 @@ func (p *Provisioner) Provision(ctx context.Context, ui packersdk.Ui, comm packe
 		p.config.PolicyGroup,
 		p.config.PolicyName,
 		p.config.SslVerifyMode,
-		p.config.TrustedCertsDir)
+		p.config.TrustedCertsDir,
+		p.config.RubygemsURL)
 	if err != nil {
 		return fmt.Errorf("Error creating Chef config file: %s", err)
 	}
@@ -386,7 +389,8 @@ func (p *Provisioner) createConfig(
 	policyGroup string,
 	policyName string,
 	sslVerifyMode string,
-	trustedCertsDir string) (string, error) {
+	trustedCertsDir string,
+	rubygemsURL string) (string, error) {
 
 	ui.Message("Creating configuration file 'client.rb'")
 
@@ -418,6 +422,7 @@ func (p *Provisioner) createConfig(
 		ChefEnvironment:            chefEnvironment,
 		PolicyGroup:                policyGroup,
 		PolicyName:                 policyName,
+		RubygemsURL:                rubygemsURL,
 		SslVerifyMode:              sslVerifyMode,
 		TrustedCertsDir:            trustedCertsDir,
 		EncryptedDataBagSecretPath: encryptedDataBagSecretPath,
@@ -775,6 +780,9 @@ ssl_verify_mode :{{.SslVerifyMode}}
 {{end}}
 {{if ne .TrustedCertsDir ""}}
 trusted_certs_dir "{{.TrustedCertsDir}}"
+{{end}}
+{{if ne .RubygemsURL ""}}
+rubygems_url "{{.RubygemsURL}}"
 {{end}}
 `
 

--- a/provisioner/chef-client/provisioner_test.go
+++ b/provisioner/chef-client/provisioner_test.go
@@ -39,6 +39,23 @@ func TestProvisionerPrepare_chefEnvironment(t *testing.T) {
 	}
 }
 
+func TestProvisionerPrepare_rubygemsURL(t *testing.T) {
+	var p Provisioner
+
+	config := testConfig()
+	rubygemsURL := "https://rubygems.org"
+	config["rubygems_url"] = rubygemsURL
+
+	err := p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if p.config.RubygemsURL != rubygemsURL {
+		t.Fatalf("unexpected: %#v", p.config.RubygemsURL)
+	}
+}
+
 func TestProvisionerPrepare_configTemplate(t *testing.T) {
 	var err error
 	var p Provisioner


### PR DESCRIPTION
In an enterprise environment that does not have direct access to the internet you may need to specify a custom rubygems_url to install gems for chef cookbook dependencies.