### PR TITLE
Fix plugin registration for chef-client and chef-solo

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,8 +27,8 @@ var (
 
 func main() {
 	pps := plugin.NewSet()
-	pps.RegisterProvisioner("chef-client", new(chefclient.Provisioner))
-	pps.RegisterProvisioner("chef-solo", new(chefsolo.Provisioner))
+	pps.RegisterProvisioner("client", new(chefclient.Provisioner))
+	pps.RegisterProvisioner("solo", new(chefsolo.Provisioner))
 	pps.SetVersion(PluginVersion)
 	err := pps.Run()
 	if err != nil {


### PR DESCRIPTION
Before Change
```
known provisioners: [shell-local chef-solo powershell sleep ansible
shell
windows-shell azure-dtlartifact puppet-masterless
scaffolding-ansible-local
chef-client converge scaffolding windows-restart file salt-masterless
puppet-server inspec chef-chef-client chef-chef-solo ansible-local
breakpoint]
```

After Change
```
==> docker.autogenerated_1: Provisioning with chef-solo
    docker.autogenerated_1: Installing Chef...
==> docker.autogenerated_1:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
==> docker.autogenerated_1:                                  Dload  Upload   Total   Spent    Left  Speed
==> docker.autogenerated_1: 100 23409  100 23409    0     0  34628      0 --:--:-- --:--:-- --:--:-- 34628
    docker.autogenerated_1: ubuntu 20.04 x86_64
    docker.autogenerated_1: Getting information for chef stable  for ubuntu...
    docker.autogenerated_1: downloading https://omnitruck.chef.io/stable/chef/metadata?v=&p=ubuntu&pv=20.04&m=x86_64
    docker.autogenerated_1:   to file /tmp/install.sh.2886/metadata.txt
    docker.autogenerated_1: trying curl...
    docker.autogenerated_1: sha1        e47331391e1b5a8db6892fa7817883f21dc22b12
    docker.autogenerated_1: sha256      7ca4edcc38730c2e9f8862f0ee2c3e74e75f54d54df60e24341de6278e922b75
    docker.autogenerated_1: url https://packages.chef.io/files/stable/chef/17.0.242/ubuntu/20.04/chef_17.0.242-1_amd64.deb
    docker.autogenerated_1: version     17.0.242
    docker.autogenerated_1: downloaded metadata file looks valid...
    docker.autogenerated_1: downloading https://packages.chef.io/files/stable/chef/17.0.242/ubuntu/20.04/chef_17.0.242-1_amd64.deb
    docker.autogenerated_1:   to file /tmp/install.sh.2886/chef_17.0.242-1_amd64.deb
    docker.autogenerated_1: trying curl...
    docker.autogenerated_1: Comparing checksum with sha256sum...
    docker.autogenerated_1:
    docker.autogenerated_1: WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
```
